### PR TITLE
Update util.ts fix RegEx typo on ROUTING_STRING_REGEX

### DIFF
--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -50,4 +50,10 @@ test('parseAudioRoutingStringSingle', () => {
 
 	const parse5 = parseAudioRoutingStringSingle('9291-8_9')
 	expect(parse5).toEqual(null)
+	
+	const parse6 = parseAudioRoutingStringSingle('2001-9_10')
+	expect(parse6).toEqual(combineInputId(2001, AudioChannelPair.Channel9_10))
+
+	const parse7 = parseAudioRoutingStringSingle('2001-15_16')
+	expect(parse7).toEqual(combineInputId(2001, AudioChannelPair.Channel15_16))
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -122,7 +122,7 @@ export function parseAudioRoutingString(ids: string): number[] {
 		.filter((id): id is number => id !== null)
 }
 
-const ROUTING_STRING_REGEX = /(\d+)-([\d]+_[\d+])/i
+const ROUTING_STRING_REGEX = /(\d+)-([\d]+_[\d]+)/i
 export function parseAudioRoutingStringSingle(id: string): number | null {
 	id = id.trim()
 	if (!id) return null


### PR DESCRIPTION
corrects regex pattern ROUTING_STRING_REGEX, so that AudioRoutingStrings with two digits at the end can be parsed correctly. https://github.com/bitfocus/companion-module-bmd-atem/issues/343